### PR TITLE
Corrected name of email environment variable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ node{
 }
 
 def processStageResult() {
-    step([$class: 'Mailer', notifyEveryUnstableBuild: true, recipients: "${env.EMAIL}", sendToIndividuals: false])
+    step([$class: 'Mailer', notifyEveryUnstableBuild: true, recipients: "${EMAIL}", sendToIndividuals: false])
 
     if (currentBuild.result != null) {
         sh "exit 0"


### PR DESCRIPTION
Corrected the name of the environment variable containing the list of email recipients. Emails were not being sent successfully. 