### PR TITLE
Updated Jenkinsfile to inject environment variables in build stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,20 +7,36 @@ node{
 
     stage 'build and unit test'
     
-        kubernetes.pod('buildtestpod').withImage('maven')
-        .withPrivileged(true)
-        .withSecret('jenkins-maven-settings','/root/.m2')
-        .inside {
-            try {
-                sh 'mvn -Dmaven.test.failure.ignore clean install'
-                step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/TEST-*.xml'])
-            }
-            catch(e) {
-                currentBuild.result = 'FAILURE'
-                throw e
-            }
-            finally {
-                processStageResult()
+        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'distortion-gh-test-user-pw',
+        usernameVariable: 'GITHUB_USERNAME', passwordVariable: 'GITHUB_PASSWORD']]) {
+
+            withCredentials([[$class: 'StringBinding',
+            credentialsId: 'distortion-gh-test-access-token', variable: 'GITHUB_TOKEN']]) {
+
+                withCredentials([[$class: 'StringBinding',
+                credentialsId: 'distortion-gh-test-client-id', variable: 'KONTINUITY_CATAPULT_GITHUB_APP_CLIENT_ID']]) {
+
+                    withCredentials([[$class: 'StringBinding',
+                    credentialsId: 'distortion-gh-test-client-secret', variable: 'KONTINUITY_CATAPULT_GITHUB_APP_CLIENT_SECRET']]) {
+
+                        kubernetes.pod('buildtestpod').withImage('maven')
+                        .withPrivileged(true)
+                        .withSecret('jenkins-maven-settings','/root/.m2')
+                        .inside {
+                            try {
+                                sh 'mvn -Dmaven.test.failure.ignore clean install'
+                                step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/TEST-*.xml'])
+                            }
+                            catch(e) {
+                                currentBuild.result = 'FAILURE'
+                                throw e
+                            }
+                            finally {
+                                processStageResult()
+                            }
+                        }
+                    }
+                }
             }
         }
         


### PR DESCRIPTION
Lack of environment variable injection in build state of Jenkinsfile pipeline definition was causing tests to become unstable during CI testing

[Passing build using feature branch](http://jenkins.master.distortion.example.com/job/ablock-distortion-test-branch/2/)