### PR TITLE
make throw correct exception as javadoc states

### DIFF
--- a/core/core-api/src/main/java/org/kontinuity/catapult/core/api/ProjectileBuilder.java
+++ b/core/core-api/src/main/java/org/kontinuity/catapult/core/api/ProjectileBuilder.java
@@ -63,7 +63,7 @@ public class ProjectileBuilder {
                                 final String value) throws IllegalStateException {
         assert name != null && !name.isEmpty() : "name is required";
         if (value == null || value.isEmpty()) {
-            throw new IllegalArgumentException(name + " must be specified");
+            throw new IllegalStateException(name + " must be specified");
         }
     }
 


### PR DESCRIPTION
https://github.com/redhat-kontinuity/catapult/issues/83

Not sure why unit tests are failing regardless of this fix - I'm looking for any hints about it

```
Tests in error: 
  GitHubServiceTest.cannotForkNonexistentRepo »  Unexpected exception, expected<...
  GitHubServiceTest.createGithubWebHook:12->GitHubServiceTestBase.createGithubWebHook:56->getGitHubService:17 » IllegalState
  GitHubServiceTest.fork:12->GitHubServiceTestBase.fork:40->getGitHubService:17 » IllegalState
  GitHubServiceTest.forkRepoCannotBeEmpty »  Unexpected exception, expected<java...
  GitHubServiceTest.forkRepoCannotBeNull »  Unexpected exception, expected<java....
```
