### PR TITLE
Issue 97 - Configure pipeline on OpenShift when creating project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docs/reference/src/main/docbook/en-US/version_info.xml
 .factorypath
 atlassian-ide-plugin.xml
 .externalToolBuilders
+.tern-project

--- a/core/core-api/src/main/java/org/kontinuity/catapult/core/api/Projectile.java
+++ b/core/core-api/src/main/java/org/kontinuity/catapult/core/api/Projectile.java
@@ -12,6 +12,9 @@ public class Projectile {
 
     private final String gitHubAccessToken;
 
+    /** the name of the file in the repo that contains the pipeline template. */
+	private String openshiftProjectTemplateFileName = "pipelinetemplate.json";
+
     /**
      * Package-level access; to be invoked by {@link ProjectileBuilder}
      * and all precondition checks are its responsibility
@@ -19,6 +22,7 @@ public class Projectile {
     Projectile(final ProjectileBuilder builder){
         this.sourceGitHubRepo = builder.getSourceGitHubRepo();
         this.gitHubAccessToken = builder.getGitHubAccessToken();
+        this.openshiftProjectTemplateFileName = builder.getOpenShiftProjectTemplateFileName();
     }
 
     /**
@@ -26,13 +30,21 @@ public class Projectile {
      * the OAuth process
      */
     public String getGitHubAccessToken() {
-        return gitHubAccessToken;
+        return this.gitHubAccessToken;
     }
 
     /**
      * @return source GitHub repository name in form "owner/repoName".
      */
     public String getSourceGitHubRepo() {
-        return sourceGitHubRepo;
+        return this.sourceGitHubRepo;
     }
+
+    /**
+	 * @return the name of the file that contains the pipeline template to apply
+	 *         on the OpenShift project.
+	 */
+	public String getOpenShiftProjectTemplateFileName() {
+		return this.openshiftProjectTemplateFileName;
+	}
 }

--- a/core/core-api/src/main/java/org/kontinuity/catapult/core/api/ProjectileBuilder.java
+++ b/core/core-api/src/main/java/org/kontinuity/catapult/core/api/ProjectileBuilder.java
@@ -19,6 +19,9 @@ public class ProjectileBuilder {
     private String sourceGitHubRepo;
 
     private String gitHubAccessToken;
+    
+    /** the name of the file in the repo that contains the pipeline template. */
+	private String openshiftProjectTemplateFileName;
 
     private ProjectileBuilder(){
         // No external instances
@@ -45,6 +48,7 @@ public class ProjectileBuilder {
         // Precondition checks
     	ProjectileBuilder.checkSpecified("sourceGitHubRepo", sourceGitHubRepo);
     	ProjectileBuilder.checkSpecified("gitHubAccessToken", gitHubAccessToken);
+    	ProjectileBuilder.checkSpecified("projectTemplateFileName", openshiftProjectTemplateFileName);
 
         // All good, so make a new instance
         final Projectile projectile = new Projectile(this);
@@ -93,7 +97,19 @@ public class ProjectileBuilder {
         this.gitHubAccessToken = gitHubAccessToken;
         return this;
     }
-    
+
+	/**
+	 * Sets the name of the file that contains the template to apply on the
+	 * OpenShift project. Required
+	 *
+	 * @param openshiftProjectTemplateFileName
+	 * @return This builder
+	 */
+	public ProjectileBuilder openshiftProjectTemplateFileName(final String openshiftProjectTemplateFileName) {
+		this.openshiftProjectTemplateFileName = openshiftProjectTemplateFileName;
+		return this;
+	}
+
     /**
      * @return source GitHub repository name in form "owner/repoName".
      */
@@ -108,4 +124,12 @@ public class ProjectileBuilder {
     public String getGitHubAccessToken() {
         return this.gitHubAccessToken;
     }
+    
+    /**
+	 * @return the name of the file that contains the template to apply
+	 *         on the OpenShift project.
+	 */
+	public String getOpenShiftProjectTemplateFileName() {
+		return this.openshiftProjectTemplateFileName;
+	}
 }

--- a/core/core-impl/src/main/java/org/kontinuity/catapult/core/impl/CatapultImpl.java
+++ b/core/core-impl/src/main/java/org/kontinuity/catapult/core/impl/CatapultImpl.java
@@ -1,5 +1,7 @@
 package org.kontinuity.catapult.core.impl;
 
+import java.net.URI;
+
 import javax.inject.Inject;
 
 import org.kontinuity.catapult.core.api.Boom;
@@ -52,6 +54,10 @@ public class CatapultImpl implements Catapult {
         final OpenShiftProject createdProject;
         try {
             createdProject = openShiftService.createProject(projectName);
+            final URI projectTemplateDownloadUri = forkedRepo.getDownloadUri(projectile.getOpenShiftProjectTemplateFileName());
+            if(projectTemplateDownloadUri != null) { 
+            	openShiftService.configureProject(createdProject, forkedRepo.getGitCloneUri(), projectTemplateDownloadUri);
+            }
         } catch (final DuplicateProjectException dpe) {
             //TODO
             /*

--- a/core/core-impl/src/test/java/org/kontinuity/catapult/core/impl/CatapultIT.java
+++ b/core/core-impl/src/test/java/org/kontinuity/catapult/core/impl/CatapultIT.java
@@ -1,11 +1,17 @@
 package org.kontinuity.catapult.core.impl;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.logging.Logger;
+
+import javax.inject.Inject;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.junit.After;
 import org.junit.Assert;
@@ -17,16 +23,14 @@ import org.kontinuity.catapult.core.api.Catapult;
 import org.kontinuity.catapult.core.api.Projectile;
 import org.kontinuity.catapult.core.api.ProjectileBuilder;
 import org.kontinuity.catapult.service.github.api.GitHubRepository;
+import org.kontinuity.catapult.service.github.api.GitHubService;
+import org.kontinuity.catapult.service.github.api.GitHubServiceFactory;
+import org.kontinuity.catapult.service.github.api.NoSuchRepositoryException;
+import org.kontinuity.catapult.service.github.spi.GitHubServiceSpi;
 import org.kontinuity.catapult.service.github.test.GitHubTestCredentials;
 import org.kontinuity.catapult.service.openshift.api.OpenShiftProject;
 import org.kontinuity.catapult.service.openshift.api.OpenShiftService;
 import org.kontinuity.catapult.service.openshift.spi.OpenShiftServiceSpi;
-
-import javax.inject.Inject;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.logging.Logger;
 
 /**
  * Test cases for the {@link Catapult}
@@ -38,11 +42,16 @@ import java.util.logging.Logger;
 public class CatapultIT {
 
     private static final Logger log = Logger.getLogger(CatapultIT.class.getName());
-    private static final String NAME_GITHUB_SOURCE_REPO = "jboss-developer/jboss-eap-quickstarts";
+    private static final String GITHUB_SOURCE_REPO_NAME = "kitchensink-html5-mobile";
+    private static final String GITHUB_SOURCE_REPO_FULLNAME = "redhat-kontinuity/" + GITHUB_SOURCE_REPO_NAME;
+    private static final String PROJECT_TEMPLATE_FILENAME = "pipelinetemplate.json";
     private final Collection<String> openshiftProjectsToDelete = new ArrayList<>();
 
     @Inject
     private OpenShiftService openShiftService; 
+    
+    @Inject
+    private GitHubServiceFactory gitHubServiceFactory; 
     
     @Inject
     private Catapult catapult;
@@ -52,46 +61,58 @@ public class CatapultIT {
 	 *         to test the {@link Catapult}
 	 */
 	@Deployment(testable = true)
-	public static EnterpriseArchive createDeployment() {
-      final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "catapult-core-test.jar")
-              .addPackage(Catapult.class.getPackage())
-              .addPackage(CatapultImpl.class.getPackage())
-              .addPackage(GitHubTestCredentials.class.getPackage())
-              .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-      // Import Maven runtime dependencies
-		final File[] dependencies = Maven.resolver().loadPomFromFile("pom.xml").importRuntimeDependencies().resolve()
-		        .withTransitivity().asFile();
-		// Create the deployable archive
-		final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class).addAsLibraries(dependencies)
-		        .addAsLibraries(jar);
-		// Show the deployed structure
-		log.info(ear.toString(true));
-		return ear;
+	public static WebArchive createDeployment() {
+		// Import Maven runtime dependencies
+        final File[] dependencies = Maven.resolver().loadPomFromFile("pom.xml")
+                .importRuntimeDependencies().resolve().withTransitivity().asFile();
+        // Create deploy file    
+        final WebArchive war = ShrinkWrap.create(WebArchive.class)
+        		.addPackage(Catapult.class.getPackage())
+                .addPackage(CatapultImpl.class.getPackage())
+                .addPackage(GitHubTestCredentials.class.getPackage())
+                .addAsWebInfResource("META-INF/jboss-deployment-structure.xml", "jboss-deployment-structure.xml")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsLibraries(dependencies);
+        // Show the deployed structure
+        log.info(war.toString(true)); 
+        return war;
 	}
 
 	@Before
+	@After
 	public void reset() {
-		openshiftProjectsToDelete.clear();
+		// also, make sure that the GitHub user's account does not already contain the repo to fork
+		// After the test remove the repository we created
+		final String repositoryName = GitHubTestCredentials.getUsername() + "/" + GITHUB_SOURCE_REPO_NAME;
+		try {
+			final GitHubService gitHubService = gitHubServiceFactory.create(GitHubTestCredentials.getToken());
+			((GitHubServiceSpi) gitHubService).deleteRepository(repositoryName);
+		} catch (NoSuchRepositoryException e) {
+			// ignore
+			log.info("Repository '" + repositoryName + "' does not exist.");
+		}
 	}
     
-    @After
-    public void cleanup() {
-        openshiftProjectsToDelete.forEach(projectName -> {
-            final boolean deleted = ((OpenShiftServiceSpi) openShiftService).deleteProject(projectName);
-            if (deleted) {
-                log.info("Deleted project: " + projectName);
-            }
-        });
+	@Before
+	@After
+    public void cleanupOpenShiftProjects() {
+		openshiftProjectsToDelete.forEach(projectName -> {
+			final boolean deleted = ((OpenShiftServiceSpi) openShiftService).deleteProject(projectName);
+			if (deleted) {
+				log.info("Deleted project: " + projectName);
+			}
+		});
+		openshiftProjectsToDelete.clear();
     }
 
     @Test
     public void fling() {
-
         // Define the projectile
-        //TODO Inject the GitHubServiceProducer
         final Projectile projectile = ProjectileBuilder.newInstance().
                 gitHubAccessToken(GitHubTestCredentials.getToken()).
-                sourceGitHubRepo(NAME_GITHUB_SOURCE_REPO).build();
+                sourceGitHubRepo(GITHUB_SOURCE_REPO_FULLNAME).
+                openshiftProjectTemplateFileName(PROJECT_TEMPLATE_FILENAME).
+                build();
 
         // Fling
         final Boom boom = catapult.fling(projectile);
@@ -101,9 +122,9 @@ public class CatapultIT {
         Assert.assertNotNull("repo can not be null", createdRepo);
         final OpenShiftProject createdProject = boom.getCreatedProject();
         Assert.assertNotNull("project can not be null", createdProject);
-        final String expectedName = NAME_GITHUB_SOURCE_REPO.substring(
-                NAME_GITHUB_SOURCE_REPO.lastIndexOf('/') + 1,
-                NAME_GITHUB_SOURCE_REPO.length());
+        final String expectedName = GITHUB_SOURCE_REPO_NAME.substring(
+                GITHUB_SOURCE_REPO_NAME.lastIndexOf('/') + 1,
+                GITHUB_SOURCE_REPO_NAME.length());
         final String foundName = createdProject.getName();
         log.info("Created OpenShift project: " + foundName);
         openshiftProjectsToDelete.add(foundName);

--- a/core/core-impl/src/test/java/org/kontinuity/catapult/core/impl/ProjectileBuilderTest.java
+++ b/core/core-impl/src/test/java/org/kontinuity/catapult/core/impl/ProjectileBuilderTest.java
@@ -16,31 +16,46 @@ public class ProjectileBuilderTest {
    private static final String SOME_VALUE = "test";
    private static final String EMPTY = "";
 
-   @Test(expected = IllegalStateException.class)
-   public void requiresSourceGitHubRepo() {
-      ProjectileBuilder.newInstance().gitHubAccessToken(SOME_VALUE).build();
-   }
+	@Test(expected = IllegalStateException.class)
+	public void requiresSourceGitHubRepo() {
+		ProjectileBuilder.newInstance().gitHubAccessToken(SOME_VALUE).openshiftProjectTemplateFileName(SOME_VALUE)
+		        .build();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void requiresGitHubAccessToken() {
+		ProjectileBuilder.newInstance().sourceGitHubRepo(SOME_VALUE).openshiftProjectTemplateFileName(SOME_VALUE)
+		        .build();
+	}
 
    @Test(expected = IllegalStateException.class)
-   public void requiresGitHubAccessToken() {
-      ProjectileBuilder.newInstance().sourceGitHubRepo(SOME_VALUE).build();
+   public void requiresOpenshiftProjectTemplateFileName() {
+	   ProjectileBuilder.newInstance().sourceGitHubRepo(SOME_VALUE).gitHubAccessToken(SOME_VALUE).build();
    }
+   
+	@Test(expected = IllegalStateException.class)
+	public void requiresSourceGitHubRepoNotEmpty() {
+		ProjectileBuilder.newInstance().gitHubAccessToken(SOME_VALUE).sourceGitHubRepo(EMPTY)
+		        .openshiftProjectTemplateFileName(SOME_VALUE).build();
+	}
 
-   @Test(expected = IllegalStateException.class)
-   public void requiresSourceGitHubRepoNotEmpty() {
-      ProjectileBuilder.newInstance().gitHubAccessToken(SOME_VALUE).sourceGitHubRepo(EMPTY).build();
-   }
+	@Test(expected = IllegalStateException.class)
+	public void requiresGitHubAccessTokenNotEmpty() {
+		ProjectileBuilder.newInstance().sourceGitHubRepo(SOME_VALUE).gitHubAccessToken(EMPTY)
+		        .openshiftProjectTemplateFileName(SOME_VALUE).build();
+	}
 
-   @Test(expected = IllegalStateException.class)
-   public void requiresGitHubAccessTokenNotEmpty() {
-      ProjectileBuilder.newInstance().sourceGitHubRepo(SOME_VALUE).gitHubAccessToken(EMPTY).build();
-   }
-
-   @Test
-   public void createsInstance() {
-      final Projectile projectile = ProjectileBuilder.newInstance().
-              sourceGitHubRepo(SOME_VALUE).gitHubAccessToken(SOME_VALUE).build();
-      Assert.assertNotNull(projectile);
-   }
+	@Test(expected = IllegalStateException.class)
+	public void requiresOpenshiftProjectTemplateFileNameNotEmpty() {
+		ProjectileBuilder.newInstance().sourceGitHubRepo(SOME_VALUE).gitHubAccessToken(SOME_VALUE)
+		        .openshiftProjectTemplateFileName(EMPTY).build();
+	}
+   
+	@Test
+	public void createsInstance() {
+		final Projectile projectile = ProjectileBuilder.newInstance().sourceGitHubRepo(SOME_VALUE)
+		        .gitHubAccessToken(SOME_VALUE).openshiftProjectTemplateFileName(SOME_VALUE).build();
+		Assert.assertNotNull(projectile);
+	}
 
 }

--- a/core/core-impl/src/test/resources/jboss-deployment-structure.xml
+++ b/core/core-impl/src/test/resources/jboss-deployment-structure.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
+    <deployment>
+        <exclusions>
+            <module name="org.jboss.resteasy.resteasy-jackson2-provider" />
+            <module name="com.fasterxml.jackson.core.jackson-annotations" />
+            <module name="com.fasterxml.jackson.core.jackson-core" />
+            <module name="com.fasterxml.jackson.core.jackson-databind" />
+            <module
+                name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" />
+        </exclusions>
+
+    </deployment>
+</jboss-deployment-structure>

--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,13 @@
         <version.arquillian_universe>1.0.0.Alpha2</version.arquillian_universe>
         <version.org.arquillian.container_arquillian-container-chameleon>1.0.0.Alpha6</version.org.arquillian.container_arquillian-container-chameleon>
         <version.org.kohsuke_github-api>1.73</version.org.kohsuke_github-api>
-        <version.io.fabric8_openshift-client>1.3.78</version.io.fabric8_openshift-client>
+        <version.io.fabric8_openshift-client>1.3.96</version.io.fabric8_openshift-client>
+        <version.io.fabric8_kubernetes-api>2.2.131</version.io.fabric8_kubernetes-api>
         <version.com.fasterxml.jackson>2.7.0</version.com.fasterxml.jackson>
         <version.com.squareup.okhttp>2.7.2</version.com.squareup.okhttp>
         <version.org.jboss.arquillian.extension_arquillian-phantom-driver>1.2.1.Final</version.org.jboss.arquillian.extension_arquillian-phantom-driver>
+        <version.ch.qos.logback_logback-classic>1.0.13</version.ch.qos.logback_logback-classic>
+        <version.org.assertj_assertj-core>3.4.1</version.org.assertj_assertj-core>
 
     </properties>
     <modules>
@@ -130,6 +133,11 @@
                 <version>${version.io.fabric8_openshift-client}</version>
             </dependency>
             <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-api</artifactId>
+                <version>${version.io.fabric8_kubernetes-api}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.arquillian</groupId>
                 <artifactId>arquillian-universe</artifactId>
                 <version>${version.arquillian_universe}</version>
@@ -188,6 +196,18 @@
                 <version>${version.org.jboss.arquillian.extension_arquillian-phantom-driver}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${version.ch.qos.logback_logback-classic}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${version.org.assertj_assertj-core}</version>
+            <scope>test</scope>
+        </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/services/github-service-api/src/main/java/org/kontinuity/catapult/service/github/api/GitHubRepository.java
+++ b/services/github-service-api/src/main/java/org/kontinuity/catapult/service/github/api/GitHubRepository.java
@@ -1,6 +1,7 @@
 package org.kontinuity.catapult.service.github.api;
 
 import java.net.URI;
+import java.net.URL;
 
 /**
  * Value object representing a repository in GitHub
@@ -8,11 +9,6 @@ import java.net.URI;
  * @author <a href="mailto:alr@redhat.com">Andrew Lee Rubinger</a>
  */
 public interface GitHubRepository {
-
-    /**
-     * @return the "git" protocol transport URL
-     */
-    String getGitTransportUrl();
 
     /**
      * @return the full repository name in form "owner/repoName"
@@ -23,4 +19,20 @@ public interface GitHubRepository {
      * @return the github.com page for the repository
      */
     URI getHomepage();
+
+	/**
+	 * @param path
+	 *            the path to the file
+	 * @return the {@link URI} of the file with the given {@code} in the GitHub
+	 *         repository
+	 * @throws RuntimeException
+	 *             if no file with the given {@code path} exists in the
+	 *             repository
+	 */
+	URI getDownloadUri(String path);
+
+	/**
+	 * @return the {@link URI} to use to clone the project from GitHub
+	 */
+	URI getGitCloneUri();
 }

--- a/services/github-service-api/src/main/java/org/kontinuity/catapult/service/github/api/NoSuchRepositoryException.java
+++ b/services/github-service-api/src/main/java/org/kontinuity/catapult/service/github/api/NoSuchRepositoryException.java
@@ -1,7 +1,5 @@
 package org.kontinuity.catapult.service.github.api;
 
-import java.text.MessageFormat;
-
 /**
  * Indicates a specified repository does not exist.
  *
@@ -12,14 +10,11 @@ public class NoSuchRepositoryException extends RuntimeException {
     /** version number of this serializable class. */
     private static final long serialVersionUID = -78123136358123472L;
     
-    /** The message pattern. */
-    private static final String MSG_PATTERN = "No such repository named {0}";
-
     /**
      * Constructor
-     * @param repositoryName name of the GitHub repository
+     * @param message the exception message
      */
-    public NoSuchRepositoryException(final String repositoryName) {
-        super(MessageFormat.format(MSG_PATTERN, repositoryName));
+    public NoSuchRepositoryException(final String message) {
+        super(message);
     }
 }

--- a/services/github-service-impl/src/main/java/org/kontinuity/catapult/service/github/impl/kohsuke/InvalidPathException.java
+++ b/services/github-service-impl/src/main/java/org/kontinuity/catapult/service/github/impl/kohsuke/InvalidPathException.java
@@ -1,0 +1,23 @@
+package org.kontinuity.catapult.service.github.impl.kohsuke;
+
+import java.net.URISyntaxException;
+
+/**
+ * Exception thrown when the path to a repository on GitHub is invalid
+ */
+public class InvalidPathException extends IllegalArgumentException {
+
+	private static final long serialVersionUID = 450790118418275921L;
+
+	/**
+	 * Constructor.
+	 * @param message the exception message
+	 * @param cause the underlying cause
+	 */
+	public InvalidPathException(String message, URISyntaxException cause) {
+		super(message, cause);
+	}
+	
+	
+
+}

--- a/services/github-service-impl/src/main/java/org/kontinuity/catapult/service/github/impl/kohsuke/KohsukeGitHubRepositoryImpl.java
+++ b/services/github-service-impl/src/main/java/org/kontinuity/catapult/service/github/impl/kohsuke/KohsukeGitHubRepositoryImpl.java
@@ -1,11 +1,14 @@
 package org.kontinuity.catapult.service.github.impl.kohsuke;
 
-import org.kohsuke.github.GHRepository;
-import org.kontinuity.catapult.service.github.api.GitHubRepository;
-
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.logging.Logger;
+
+import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHRepository;
+import org.kontinuity.catapult.service.github.api.GitHubRepository;
 
 /**
  * Kohsuke implementation of a {@link GitHubRepository}
@@ -14,7 +17,6 @@ import java.util.logging.Logger;
  */
 class KohsukeGitHubRepositoryImpl implements GitHubRepository {
 
-    @SuppressWarnings("unused")
 	private Logger log = Logger.getLogger(KohsukeGitHubRepositoryImpl.class.getName());
 
     private final GHRepository delegate;
@@ -33,14 +35,6 @@ class KohsukeGitHubRepositoryImpl implements GitHubRepository {
      * {@inheritDoc}
      */
     @Override
-    public String getGitTransportUrl() {
-        return delegate.getGitTransportUrl();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public String getFullName() {
         return delegate.getFullName();
     }
@@ -53,10 +47,36 @@ class KohsukeGitHubRepositoryImpl implements GitHubRepository {
         try {
             return delegate.getHtmlUrl().toURI();
         } catch (final URISyntaxException urise) {
-            throw new RuntimeException("GitHub Homepage URL can't be represented as URI", urise);
+            throw new InvalidPathException("GitHub Homepage URL can't be represented as URI", urise);
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public URI getDownloadUri(final String path) {
+		try {
+			final GHContent fileContent = delegate.getFileContent(path);
+			return new URI(fileContent.getDownloadUrl());
+		} catch (FileNotFoundException e) {
+			throw new RuntimeException(
+			        "No file named '" + path + "' could be found in repository '" + delegate.getFullName() + "'");
+		} catch (IOException | URISyntaxException e) {
+			throw new RuntimeException("Exception occurred while trying to get the download URL for file '" + path
+			        + "' in repo '" + delegate.getFullName() + "'", e);
+		}
+    }
+    
+    @Override
+    public URI getGitCloneUri() {
+    	try {
+    		return new URI(delegate.gitHttpTransportUrl());
+		} catch (URISyntaxException e) {
+			throw new RuntimeException("Exception occurred while trying to get the clone URL for repo '" + delegate.getFullName() + "'", e);
+		}
+
+    }
     /**
      * {@inheritDoc}
      */

--- a/services/github-service-impl/src/main/java/org/kontinuity/catapult/service/github/spi/GitHubServiceSpi.java
+++ b/services/github-service-impl/src/main/java/org/kontinuity/catapult/service/github/spi/GitHubServiceSpi.java
@@ -25,10 +25,18 @@ public interface GitHubServiceSpi extends GitHubService {
     /**
      * Delete a repository specified by its value object representation.
      *
-     * @param repository - the value objct the represents the Gitub repository
+     * @param repository - the value object the represents the GitHub repository
      * @throws IllegalArgumentException
      */
     void deleteRepository(final GitHubRepository repository) throws IllegalArgumentException;
+    
+    /**
+     * Delete a repository specified by its full name.
+     *
+     * @param repositoryName - GitHub repository name
+     * @throws IllegalArgumentException
+     */
+    void deleteRepository(String repositoryName) throws IllegalArgumentException;
     
     /**
      * Deletes a webhook in a specific GitHub repository
@@ -38,5 +46,14 @@ public interface GitHubServiceSpi extends GitHubService {
      * @throws IllegalArgumentException If either parameter is unspecified
      */
     void deleteWebhook(final GitHubRepository repository, GitHubWebhook webhook) throws IllegalArgumentException;
-    
+
+
+    /**
+     * Checks if the repository with the given name exists
+     * @param repositoryName
+     * @return <code>true</code> if it exists, <code>false</code> otherwise.
+     */
+	boolean repositoryExists(String repositoryName);
+
+
 }

--- a/services/github-service-impl/src/test/java/org/kontinuity/catapult/service/github/impl/kohsuke/GitHubServiceTestBase.java
+++ b/services/github-service-impl/src/test/java/org/kontinuity/catapult/service/github/impl/kohsuke/GitHubServiceTestBase.java
@@ -1,14 +1,23 @@
 package org.kontinuity.catapult.service.github.impl.kohsuke;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.kontinuity.catapult.service.github.api.*;
-import org.kontinuity.catapult.service.github.spi.GitHubServiceSpi;
-import org.kontinuity.catapult.service.github.test.GitHubTestCredentials;
-
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.kontinuity.catapult.service.github.api.GitHubRepository;
+import org.kontinuity.catapult.service.github.api.GitHubService;
+import org.kontinuity.catapult.service.github.api.GitHubWebhook;
+import org.kontinuity.catapult.service.github.api.GitHubWebhookEvent;
+import org.kontinuity.catapult.service.github.api.NoSuchRepositoryException;
+import org.kontinuity.catapult.service.github.spi.GitHubServiceSpi;
+import org.kontinuity.catapult.service.github.test.GitHubTestCredentials;
 
 /**
  * Base test class for extension in Unit and Integration modes
@@ -19,7 +28,7 @@ abstract class GitHubServiceTestBase {
 
 	private static final Logger log = Logger.getLogger(GitHubServiceTestBase.class.getName());
     private static final String NAME_GITHUB_SOURCE_REPO = "jboss-developer/jboss-eap-quickstarts";
-    private static final String MY_GITHUB_SOURCE_REPO = "my-test-repo";
+    private static final String MY_GITHUB_SOURCE_REPO_PREFIX = "my-test-repo-";
     private static final String MY_GITHUB_REPO_DESCRIPTION = "Test project created by Arquillian.";
 
     /**
@@ -27,6 +36,26 @@ abstract class GitHubServiceTestBase {
      */
     abstract GitHubService getGitHubService();
 
+    private final List<String> repositoryNames = new ArrayList<>();
+	
+    private String generateRepositoryName() {
+		final String repoName = this.MY_GITHUB_SOURCE_REPO_PREFIX + UUID.randomUUID().toString();
+		this.repositoryNames.add(repoName);
+		return repoName;
+	}
+
+	@Before
+	public void before() {
+		this.repositoryNames.clear();
+	}
+
+	@After
+	public void after() {
+		repositoryNames.stream().map(repo -> GitHubTestCredentials.getUsername() + '/' + repo)
+		        .filter(repo -> ((GitHubServiceSpi) getGitHubService()).repositoryExists(repo))
+		        .forEach(repo -> ((GitHubServiceSpi) getGitHubService()).deleteRepository(repo));
+	}
+	
     @Test(expected = IllegalArgumentException.class)
     public void forkRepoCannotBeNull() {
         getGitHubService().fork(null);
@@ -44,7 +73,7 @@ abstract class GitHubServiceTestBase {
         // then
         Assert.assertNotNull("Got null result in forking " + NAME_GITHUB_SOURCE_REPO, targetRepo);
         log.log(Level.INFO, "Forked " + NAME_GITHUB_SOURCE_REPO + " as " + targetRepo.getFullName() + " available at "
-                + targetRepo.getGitTransportUrl());
+                + targetRepo.getHomepage());
     }
 
     @Test(expected = NoSuchRepositoryException.class)
@@ -64,7 +93,7 @@ abstract class GitHubServiceTestBase {
     
     @Test(expected = IllegalArgumentException.class)
     public void createGitHubRepositoryDescriptionCannotBeNull() throws Exception {
-    	((GitHubServiceSpi)getGitHubService()).createRepository(MY_GITHUB_SOURCE_REPO, null);
+    	((GitHubServiceSpi)getGitHubService()).createRepository(MY_GITHUB_SOURCE_REPO_PREFIX, null);
     }
     
     @Test(expected = IllegalArgumentException.class)
@@ -79,32 +108,30 @@ abstract class GitHubServiceTestBase {
     
     @Test(expected = IllegalArgumentException.class)
     public void createGitHubRepositoryCannotDescriptionBeEmpty() throws Exception {
-    	((GitHubServiceSpi)getGitHubService()).createRepository(MY_GITHUB_SOURCE_REPO, "");
+    	((GitHubServiceSpi)getGitHubService()).createRepository(MY_GITHUB_SOURCE_REPO_PREFIX, "");
     }
     
     @Test
     public void createGitHubRepository() throws Exception {
     	// given
-    	final GitHubRepository targetRepo = ((GitHubServiceSpi)getGitHubService()).createRepository(MY_GITHUB_SOURCE_REPO, MY_GITHUB_REPO_DESCRIPTION);
+    	final String repositoryName = generateRepositoryName();
+    	// when
+    	final GitHubRepository targetRepo = ((GitHubServiceSpi)getGitHubService()).createRepository(repositoryName, MY_GITHUB_REPO_DESCRIPTION);
     	// then
-    	Assert.assertEquals(GitHubTestCredentials.getUsername() + "/" + MY_GITHUB_SOURCE_REPO, targetRepo.getFullName());
-    	// After the test remove the repository we created
-    	((GitHubServiceSpi)getGitHubService()).deleteRepository(targetRepo);
+    	Assert.assertEquals(GitHubTestCredentials.getUsername() + "/" + repositoryName, targetRepo.getFullName());
     }
 
     @Test
     public void createGithubWebHook() throws Exception {
-        // given
+    	// given
+    	final String repositoryName = generateRepositoryName();
         final URL webhookUrl = new URL("https://10.1.2.2");
-        final String testRepoName = "test-repo-name-from-catapult-tests";
-        final GitHubRepository targetRepo = ((GitHubServiceSpi)getGitHubService()).createRepository(testRepoName, MY_GITHUB_REPO_DESCRIPTION);
+        final GitHubRepository targetRepo = ((GitHubServiceSpi)getGitHubService()).createRepository(repositoryName, MY_GITHUB_REPO_DESCRIPTION);
         // when
         final GitHubWebhook webhook = getGitHubService().createWebhook(targetRepo, webhookUrl, GitHubWebhookEvent.ALL);
         // then
         Assert.assertNotNull(webhook);
         Assert.assertEquals(webhookUrl.toString(), webhook.getUrl());
-        // After the test remove the repo we created
-        ((GitHubServiceSpi) getGitHubService()).deleteRepository(targetRepo);
     }
 
 }

--- a/services/github-service-impl/src/test/java/org/kontinuity/catapult/service/github/test/GitHubRepositoryRule.java
+++ b/services/github-service-impl/src/test/java/org/kontinuity/catapult/service/github/test/GitHubRepositoryRule.java
@@ -1,0 +1,39 @@
+package org.kontinuity.catapult.service.github.test;
+
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.rules.ExternalResource;
+import org.kontinuity.catapult.service.github.api.GitHubRepository;
+import org.kontinuity.catapult.service.github.spi.GitHubServiceSpi;
+
+/**
+ * Utility class for {@link GitHubRepository} 
+ */
+public class GitHubRepositoryRule extends ExternalResource {
+
+	
+	/** the {@link GitHubServiceSpi} to use to submit the delete request. */
+	private final GitHubServiceSpi gitHubService;
+	
+	private final String repositoryNamePrefix;
+	
+	private final List<String> repositoryNames = new ArrayList<>();
+	
+	/**
+	 * Constructor
+	 * @param gitHubService
+	 */
+	public GitHubRepositoryRule(final GitHubServiceSpi gitHubService, final String repositoryNamePrefix) {
+		this.gitHubService = gitHubService;
+		this.repositoryNamePrefix = repositoryNamePrefix;
+	}
+	
+	
+
+	
+}

--- a/services/openshift-service-api/src/main/java/org/kontinuity/catapult/service/openshift/api/OpenShiftProject.java
+++ b/services/openshift-service-api/src/main/java/org/kontinuity/catapult/service/openshift/api/OpenShiftProject.java
@@ -1,6 +1,7 @@
 package org.kontinuity.catapult.service.openshift.api;
 
 import java.net.URL;
+import java.util.List;
 
 /**
  * Represents a Project in OpenShift
@@ -18,5 +19,10 @@ public interface OpenShiftProject {
     * @return the URL of the console overview page for this project
     */
    URL getConsoleOverviewUrl();
+   
+   /**
+    * @return an unmodifiable copy of the list of {@link OpenShiftResource} for this project
+    */
+   public List<OpenShiftResource> getResources();
 
 }

--- a/services/openshift-service-api/src/main/java/org/kontinuity/catapult/service/openshift/api/OpenShiftResource.java
+++ b/services/openshift-service-api/src/main/java/org/kontinuity/catapult/service/openshift/api/OpenShiftResource.java
@@ -1,0 +1,36 @@
+package org.kontinuity.catapult.service.openshift.api;
+
+/**
+ * An OpenShift resource.
+ * OpenShift resources belong to an {@link OpenShiftProject}, have a name and a kind
+ */
+public interface OpenShiftResource {
+
+	/**
+	 * @return the name of this resource
+	 */
+	String getName();
+
+	/**
+	 * @return the kind of this resource, as returned in the OpenShift API response messages.
+	 * 
+	 * <p>Example of values:
+	 * <ul>
+	 * <li>{@code Service}</li>
+	 * <li>{@code Route}</li>
+	 * <li>{@code BuildConfig}</li>
+	 * <li>{@code Pod}</li>
+	 * <li>{@code ImageStreamMapping}</li>
+	 * <li>etc.</li>
+	 * </ul></p>
+	 * 
+	 * @see <a href="https://docs.openshift.com/enterprise/3.1/architecture/core_concepts/index.html"> OpenShift Architecture - Core concepts overview</a>
+	 */
+	String getKind();
+	
+	/**
+	 * @return the parent {@link OpenShiftProject} of this OpenShift resource
+	 */
+	OpenShiftProject getProject();
+	
+}

--- a/services/openshift-service-api/src/main/java/org/kontinuity/catapult/service/openshift/api/OpenShiftService.java
+++ b/services/openshift-service-api/src/main/java/org/kontinuity/catapult/service/openshift/api/OpenShiftService.java
@@ -1,5 +1,7 @@
 package org.kontinuity.catapult.service.openshift.api;
 
+import java.net.URI;
+
 /**
  * Defines the operations we support with the OpenShift backend
  *
@@ -15,6 +17,18 @@ public interface OpenShiftService {
      * @throws DuplicateProjectException
      * @throws IllegalArgumentException  If the name is not specified
      */
-    OpenShiftProject createProject(String name) throws DuplicateProjectException,
-            IllegalArgumentException;
+    OpenShiftProject createProject(String name)
+        throws DuplicateProjectException, IllegalArgumentException;
+    
+    /**
+     * Creates all resources for the given {@code project}, using the given {@code projectTemplate}.
+     * The {@code projectTemplate} is processed on the client side and then applied on OpenShift, where all the 
+     * described resources are created.
+     *  
+     * @param project the project in which the pipeline will be created 
+     * @param sourceRepositoryUrl the location of the source repository to build the OpenShift application from 
+     * @param projectTemplate the location of the OpenShift Template to process and apply
+     */
+    void configureProject(OpenShiftProject project, URI sourceRepositoryUrl, URI projectTemplate);
+
 }

--- a/services/openshift-service-impl/pom.xml
+++ b/services/openshift-service-impl/pom.xml
@@ -11,10 +11,18 @@
 	</parent>
 	<artifactId>catapult-service-openshift-impl</artifactId>
 
+    <properties>
+        <logback-classic.version>1.0.13</logback-classic.version>
+    </properties>
+    
    <dependencies>
       <dependency>
          <groupId>io.fabric8</groupId>
          <artifactId>openshift-client</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.fabric8</groupId>
+         <artifactId>kubernetes-api</artifactId>
       </dependency>
       <dependency>
          <groupId>org.kontinuity.catapult</groupId>
@@ -30,6 +38,14 @@
         <groupId>org.arquillian.container</groupId>
         <artifactId>arquillian-container-chameleon</artifactId>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
       </dependency>
    </dependencies>
 

--- a/services/openshift-service-impl/src/main/java/org/kontinuity/catapult/service/openshift/impl/OpenShiftProjectImpl.java
+++ b/services/openshift-service-impl/src/main/java/org/kontinuity/catapult/service/openshift/impl/OpenShiftProjectImpl.java
@@ -1,10 +1,14 @@
 package org.kontinuity.catapult.service.openshift.impl;
 
 import org.kontinuity.catapult.service.openshift.api.OpenShiftProject;
+import org.kontinuity.catapult.service.openshift.api.OpenShiftResource;
 import org.kontinuity.catapult.service.openshift.api.OpenShiftSettings;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Implementation of a value object representing a project in OpenShift
@@ -17,6 +21,8 @@ public final class OpenShiftProjectImpl implements OpenShiftProject {
     private static final String CONSOLE_OVERVIEW_URL_SUFFIX = "/overview/";
 
     private final String name;
+    
+    private final List<OpenShiftResource> resources = new ArrayList<>();
 
     /**
      * Creates a new {@link OpenShiftProject} value object
@@ -58,4 +64,45 @@ public final class OpenShiftProjectImpl implements OpenShiftProject {
 
         return url;
     }
+    
+	public void addResource(final OpenShiftResource resource) {
+		this.resources.add(resource);
+	}
+    
+    @Override
+    public List<OpenShiftResource> getResources() {
+    	return Collections.unmodifiableList(this.resources);
+    }
+
+    @Override
+    public String toString() {
+    	return "[Project] " + this.name;
+    }
+    
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		OpenShiftProjectImpl other = (OpenShiftProjectImpl) obj;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		return true;
+	}
+
+    
 }

--- a/services/openshift-service-impl/src/main/java/org/kontinuity/catapult/service/openshift/impl/OpenShiftResourceImpl.java
+++ b/services/openshift-service-impl/src/main/java/org/kontinuity/catapult/service/openshift/impl/OpenShiftResourceImpl.java
@@ -1,0 +1,103 @@
+package org.kontinuity.catapult.service.openshift.impl;
+
+import org.kontinuity.catapult.service.openshift.api.OpenShiftProject;
+import org.kontinuity.catapult.service.openshift.api.OpenShiftResource;
+
+/**
+ * 
+ */
+public class OpenShiftResourceImpl implements OpenShiftResource {
+	
+	/** the resource name. */
+	private final String name;
+	
+	/** the resource type. */
+	private final String kind;
+	
+	/** the parent project. */
+	private final OpenShiftProject project;
+
+	/**
+	 * Constructor.
+	 * @param name the resource name
+	 * @param kind the resource kind
+	 * @param parent the parent project
+	 */
+	public OpenShiftResourceImpl(String name, String kind, OpenShiftProject parent) {
+		super();
+		this.name = name;
+		this.kind = kind;
+		this.project = parent;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String getKind() {
+		return kind;
+	}
+
+	@Override
+	public OpenShiftProject getProject() {
+		return project;
+	}
+
+	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((kind == null) ? 0 : kind.hashCode());
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((project == null) ? 0 : project.hashCode());
+		return result;
+	}
+	
+	@Override
+	public String toString() {
+		return "[" + this.kind + "] " + this.project.getName() + "." + this.name;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		OpenShiftResourceImpl other = (OpenShiftResourceImpl) obj;
+		if (kind == null) {
+			if (other.kind != null) {
+				return false;
+			}
+		} else if (!kind.equals(other.kind)) {
+			return false;
+		}
+		if (name == null) {
+			if (other.name != null) {
+				return false;
+			}
+		} else if (!name.equals(other.name)) {
+			return false;
+		}
+		if (project == null) {
+			if (other.project != null) {
+				return false;
+			}
+		} else if (!project.equals(other.project)) {
+			return false;
+		}
+		return true;
+	}
+	
+	
+	
+
+}

--- a/services/openshift-service-impl/src/main/resources/META-INF/jboss-deployment-structure.xml
+++ b/services/openshift-service-impl/src/main/resources/META-INF/jboss-deployment-structure.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
+    <deployment>
+        <exclusions>
+            <module name="org.jboss.resteasy.resteasy-jackson2-provider" />
+            <module name="com.fasterxml.jackson.core.jackson-annotations" />
+            <module name="com.fasterxml.jackson.core.jackson-core" />
+            <module name="com.fasterxml.jackson.core.jackson-databind" />
+            <module
+                name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" />
+        </exclusions>
+
+    </deployment>
+</jboss-deployment-structure>

--- a/services/openshift-service-impl/src/test/java/org/kontinuity/catapult/service/openshift/impl/OpenShiftServiceCdiIT.java
+++ b/services/openshift-service-impl/src/test/java/org/kontinuity/catapult/service/openshift/impl/OpenShiftServiceCdiIT.java
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith;
 import org.kontinuity.catapult.service.openshift.api.OpenShiftService;
 import org.kontinuity.catapult.service.openshift.impl.fabric8.openshift.client.Fabric8OpenShiftClientServiceImpl;
 import org.kontinuity.catapult.service.openshift.spi.OpenShiftServiceSpi;
+import org.kontinuity.catapult.service.openshift.utils.DeleteOpenShiftProjectRule;
 
 /**
  * @author <a href="mailto:alr@redhat.com">Andrew Lee Rubinger</a>
@@ -41,16 +42,19 @@ public class OpenShiftServiceCdiIT extends OpenShiftServiceTestBase {
     public static WebArchive createDeployment() {
         // Import Maven runtime dependencies
         final File[] dependencies = Maven.resolver().loadPomFromFile("pom.xml")
-                .importRuntimeDependencies().resolve().withTransitivity().asFile();
+                .importRuntimeAndTestDependencies().resolve().withTransitivity().asFile();
         // Create deploy file    
-        WebArchive war = ShrinkWrap.create(WebArchive.class)
+        final WebArchive war = ShrinkWrap.create(WebArchive.class)
                 .addPackage(Fabric8OpenShiftClientServiceImpl.class.getPackage())
                 .addPackage(OpenShiftServiceCdiIT.class.getPackage())
                 .addPackage(OpenShiftService.class.getPackage())
+                .addClass(DeleteOpenShiftProjectRule.class)
                 .addClass(OpenShiftServiceSpi.class)
+                .addAsResource("pipelinetemplate.json")
+                .addAsWebInfResource("META-INF/jboss-deployment-structure.xml", "jboss-deployment-structure.xml")
                 .addAsLibraries(dependencies);
         // Show the deployed structure
-        log.fine(war.toString(true)); 
+        log.info(war.toString(true)); 
         return war;
     }
 

--- a/services/openshift-service-impl/src/test/java/org/kontinuity/catapult/service/openshift/impl/OpenShiftServiceTestBase.java
+++ b/services/openshift-service-impl/src/test/java/org/kontinuity/catapult/service/openshift/impl/OpenShiftServiceTestBase.java
@@ -1,18 +1,22 @@
 package org.kontinuity.catapult.service.openshift.impl;
 
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.kontinuity.catapult.service.openshift.api.*;
-import org.kontinuity.catapult.service.openshift.spi.OpenShiftServiceSpi;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-import java.util.ArrayList;
-import java.util.Collection;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kontinuity.catapult.service.openshift.api.DuplicateProjectException;
+import org.kontinuity.catapult.service.openshift.api.OpenShiftProject;
+import org.kontinuity.catapult.service.openshift.api.OpenShiftService;
+import org.kontinuity.catapult.service.openshift.spi.OpenShiftServiceSpi;
+import org.kontinuity.catapult.service.openshift.utils.DeleteOpenShiftProjectRule;
 
 /**
  * @author <a href="mailto:alr@redhat.com">Andrew Lee Rubinger</a>
@@ -25,34 +29,60 @@ public abstract class OpenShiftServiceTestBase {
 
     private static final String PREFIX_NAME_PROJECT = "test-project-";
 
-    private final Collection<OpenShiftProject> createdProjects = new ArrayList<>();
-
+    private URI pipelineTemplate;
+    
     protected abstract OpenShiftService getOpenShiftService();
     
-    @After
-    public void deleteCreatedProject() {
-        createdProjects.forEach(project -> {
-            final String projectName = project.getName();
-            ((OpenShiftServiceSpi) getOpenShiftService()).deleteProject(project);
-            log.info("Deleted " + projectName);
-        });
+    public DeleteOpenShiftProjectRule deleteOpenShiftProjectRule = new DeleteOpenShiftProjectRule(((OpenShiftServiceSpi) getOpenShiftService()));
+    
+    @Before
+    public void setup() {
+    	try {
+    		this.pipelineTemplate = new URI(
+    				Thread.currentThread().getContextClassLoader().getResource("pipelinetemplate.json").toExternalForm());
+    	} catch (URISyntaxException e) {
+    		throw new RuntimeException(e);
+    	}
+      assertNotNull("No pipeline template available.", pipelineTemplate);
     }
     
     @Test
-    public void createProject() {
+    public void createProjectOnly() {
+    	// given
         final String projectName = getUniqueProjectName();
+        // when (just) creating the project
         final OpenShiftProject project = triggerCreateProject(projectName);
+        log.log(Level.INFO, "Created project: \'" + projectName + "\'");
+        // then
         final String actualName = project.getName();
-        Assert.assertEquals("returned project did not have expected name", projectName, actualName);
+        assertEquals("returned project did not have expected name", projectName, actualName);
     }
 
+    @Test
+    public void createProjectAndApplyTemplate() {
+    	// given
+    	final String projectName = getUniqueProjectName();
+    	// when creating the project and then applying the template
+    	final OpenShiftProject project = triggerCreateProject(projectName);
+    	log.log(Level.INFO, "Created project: \'" + projectName + "\'");
+    	getOpenShiftService().configureProject(project, null, pipelineTemplate);
+    	// then
+    	final String actualName = project.getName();
+    	assertEquals("returned project did not have expected name", projectName, actualName);
+    	// checking that all 8 resources were created, asserting on a couple of resources.
+    	assertThat(project.getResources()).isNotNull().hasSize(9)
+    	.contains(new OpenShiftResourceImpl("frontend", "Service", project))
+    	.contains(new OpenShiftResourceImpl("sample-pipeline", "BuildConfig", project));
+    }
+    
     @Test(expected = DuplicateProjectException.class)
     public void duplicateProjectNameShouldFail() {
+    	// given
         final OpenShiftProject project = triggerCreateProject(getUniqueProjectName());
+        // when
         final String name = project.getName();
-        getOpenShiftService().createProject(name); // Using same name should fail with DPE here
-        // Just in case the above doesn't fail
-        createdProjects.add(project);
+        getOpenShiftService().createProject(name); 
+        // then using same name should fail with DPE here
     }
 
     private String getUniqueProjectName() {
@@ -62,7 +92,7 @@ public abstract class OpenShiftServiceTestBase {
     private OpenShiftProject triggerCreateProject(final String projectName) {
         final OpenShiftProject project = getOpenShiftService().createProject(projectName);
         log.log(Level.INFO, "Created project: \'" + projectName + "\'");
-        createdProjects.add(project);
+        deleteOpenShiftProjectRule.add(project);
         return project;
     }
 }

--- a/services/openshift-service-impl/src/test/java/org/kontinuity/catapult/service/openshift/utils/DeleteOpenShiftProjectRule.java
+++ b/services/openshift-service-impl/src/test/java/org/kontinuity/catapult/service/openshift/utils/DeleteOpenShiftProjectRule.java
@@ -1,0 +1,55 @@
+package org.kontinuity.catapult.service.openshift.utils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.rules.ExternalResource;
+import org.kontinuity.catapult.service.openshift.api.OpenShiftProject;
+import org.kontinuity.catapult.service.openshift.spi.OpenShiftServiceSpi;
+
+/**
+ * JUnit rule to delete OpenShift projects at the end of a test.
+ */
+public class DeleteOpenShiftProjectRule extends ExternalResource {
+
+	/** the projects to delete. */
+	private final Collection<OpenShiftProject> createdProjects = new ArrayList<>();
+
+	/** the OpenShift service to call to delete the projects. */
+	private final OpenShiftServiceSpi openShiftService;
+
+	/**
+	 * Constructor
+	 * 
+	 * @param openShiftService
+	 *            the OpenShift service to call to delete the projects.
+	 */
+	public DeleteOpenShiftProjectRule(final OpenShiftServiceSpi openShiftService) {
+		this.openShiftService = openShiftService;
+	}
+
+	/**
+	 * Adds a project in the list of projects to delete at the end of the test.
+	 * 
+	 * @param project
+	 *            the project to delete
+	 */
+	public void add(final OpenShiftProject project) {
+		createdProjects.add(project);
+	}
+
+	@Override
+	protected void before() throws Throwable {
+		createdProjects.clear();
+	}
+
+	@Override
+	protected void after() {
+		createdProjects.forEach(project -> {
+			final String projectName = project.getName();
+			openShiftService.deleteProject(project);
+			// log.info("Deleted " + projectName);
+		});
+	}
+
+}

--- a/services/openshift-service-impl/src/test/resources/logback-test.xml
+++ b/services/openshift-service-impl/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <!-- <pattern>%d{HH:mm:ss.SSS} [%10thread] %-5level %logger{36} - %msg%n%ex{0}</pattern> -->
+      <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n%ex{0}</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.kontinuity" level="TRACE" />
+
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/services/openshift-service-impl/src/test/resources/pipelinetemplate.json
+++ b/services/openshift-service-impl/src/test/resources/pipelinetemplate.json
@@ -1,0 +1,513 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "ruby-helloworld-sample",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "This example shows how to create a simple ruby application in openshift origin v3",
+      "iconClass": "icon-ruby",
+      "tags": "instant-app,ruby,mysql"
+    }
+  },
+  "objects": [
+
+    {
+      "kind": "BuildConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "sample-pipeline",
+        "creationTimestamp": null,
+        "labels": {
+          "name": "sample-pipeline"
+        }
+      },
+      "spec": {
+        "triggers": [
+          {
+            "type": "GitHub",
+            "github": {
+              "secret": "secret101"
+            }
+          },
+          {
+            "type": "Generic",
+            "generic": {
+              "secret": "secret101"
+            }
+          }
+        ],
+        "source": {
+          "type": "Git",
+          "git": {
+            "uri": "https://github.com/openshift/ruby-hello-world"
+          }
+        },
+        "strategy": {
+          "type": "JenkinsPipeline",
+          "jenkinsPipelineStrategy": {
+            "jenkinsfile": "node('agent') {\nstage 'build'\ndef builder = new com.openshift.jenkins.plugins.pipeline.OpenShiftBuilder(\"\", \"ruby-sample-build\", \"pipelineproject\", \"\", \"\", \"\", \"\", \"true\", \"\", \"\")\nstep builder\nstage 'deploy'\ndef deployer = new com.openshift.jenkins.plugins.pipeline.OpenShiftDeployer(\"\",\"frontend\",\"pipelineproject\",\"\",\"\")\nstep deployer\n}"
+          }
+        }
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "frontend",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "web",
+            "protocol": "TCP",
+            "port": 5432,
+            "targetPort": 8080,
+            "nodePort": 0
+          }
+        ],
+        "selector": {
+          "name": "frontend"
+        },
+        "portalIP": "",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Route",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "route-edge",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "host": "www.example.com",
+        "to": {
+          "kind": "Service",
+          "name": "frontend"
+        },
+        "tls": {
+          "termination": "edge",
+          "certificate": "-----BEGIN CERTIFICATE-----\nMIIDIjCCAgqgAwIBAgIBATANBgkqhkiG9w0BAQUFADCBoTELMAkGA1UEBhMCVVMx\nCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0Rl\nZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0ExGjAYBgNVBAMMEXd3\ndy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFtcGxlQGV4YW1wbGUu\nY29tMB4XDTE1MDExMjE0MTk0MVoXDTE2MDExMjE0MTk0MVowfDEYMBYGA1UEAwwP\nd3d3LmV4YW1wbGUuY29tMQswCQYDVQQIDAJTQzELMAkGA1UEBhMCVVMxIjAgBgkq\nhkiG9w0BCQEWE2V4YW1wbGVAZXhhbXBsZS5jb20xEDAOBgNVBAoMB0V4YW1wbGUx\nEDAOBgNVBAsMB0V4YW1wbGUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMrv\ngu6ZTTefNN7jjiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm\n47VRx5Qrf/YLXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1M\nmNrQUgZyQC6XIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAGjDTALMAkGA1UdEwQC\nMAAwDQYJKoZIhvcNAQEFBQADggEBAFCi7ZlkMnESvzlZCvv82Pq6S46AAOTPXdFd\nTMvrh12E1sdVALF1P1oYFJzG1EiZ5ezOx88fEDTW+Lxb9anw5/KJzwtWcfsupf1m\nV7J0D3qKzw5C1wjzYHh9/Pz7B1D0KthQRATQCfNf8s6bbFLaw/dmiIUhHLtIH5Qc\nyfrejTZbOSP77z8NOWir+BWWgIDDB2//3AkDIQvT20vmkZRhkqSdT7et4NmXOX/j\njhPti4b2Fie0LeuvgaOdKjCpQQNrYthZHXeVlOLRhMTSk3qUczenkKTOhvP7IS9q\n+Dzv5hqgSfvMG392KWh5f8xXfJNs4W5KLbZyl901MeReiLrPH3w=\n-----END CERTIFICATE-----",
+          "key": "-----BEGIN PRIVATE KEY-----\nMIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAMrvgu6ZTTefNN7j\njiZbS/xvQjyXjYMN7oVXv76jbX8gjMOmg9m0xoVZZFAE4XyQDuCm47VRx5Qrf/YL\nXmB2VtCFvB0AhXr5zSeWzPwaAPrjA4ebG+LUo24ziS8KqNxrFs1MmNrQUgZyQC6X\nIe1JHXc9t+JlL5UZyZQC1IfaJulDAgMBAAECgYEAnxOjEj/vrLNLMZE1Q9H7PZVF\nWdP/JQVNvQ7tCpZ3ZdjxHwkvf//aQnuxS5yX2Rnf37BS/TZu+TIkK4373CfHomSx\nUTAn2FsLmOJljupgGcoeLx5K5nu7B7rY5L1NHvdpxZ4YjeISrRtEPvRakllENU5y\ngJE8c2eQOx08ZSRE4TkCQQD7dws2/FldqwdjJucYijsJVuUdoTqxP8gWL6bB251q\nelP2/a6W2elqOcWId28560jG9ZS3cuKvnmu/4LG88vZFAkEAzphrH3673oTsHN+d\nuBd5uyrlnGjWjuiMKv2TPITZcWBjB8nJDSvLneHF59MYwejNNEof2tRjgFSdImFH\nmi995wJBAMtPjW6wiqRz0i41VuT9ZgwACJBzOdvzQJfHgSD9qgFb1CU/J/hpSRIM\nkYvrXK9MbvQFvG6x4VuyT1W8mpe1LK0CQAo8VPpffhFdRpF7psXLK/XQ/0VLkG3O\nKburipLyBg/u9ZkaL0Ley5zL5dFBjTV2Qkx367Ic2b0u9AYTCcgi2DsCQQD3zZ7B\nv7BOm7MkylKokY2MduFFXU0Bxg6pfZ7q3rvg8gqhUFbaMStPRYg6myiDiW/JfLhF\nTcFT4touIo7oriFJ\n-----END PRIVATE KEY-----",
+          "caCertificate": "-----BEGIN CERTIFICATE-----\nMIIEFzCCAv+gAwIBAgIJALK1iUpF2VQLMA0GCSqGSIb3DQEBBQUAMIGhMQswCQYD\nVQQGEwJVUzELMAkGA1UECAwCU0MxFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoG\nA1UECgwTRGVmYXVsdCBDb21wYW55IEx0ZDEQMA4GA1UECwwHVGVzdCBDQTEaMBgG\nA1UEAwwRd3d3LmV4YW1wbGVjYS5jb20xIjAgBgkqhkiG9w0BCQEWE2V4YW1wbGVA\nZXhhbXBsZS5jb20wHhcNMTUwMTEyMTQxNTAxWhcNMjUwMTA5MTQxNTAxWjCBoTEL\nMAkGA1UEBhMCVVMxCzAJBgNVBAgMAlNDMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkx\nHDAaBgNVBAoME0RlZmF1bHQgQ29tcGFueSBMdGQxEDAOBgNVBAsMB1Rlc3QgQ0Ex\nGjAYBgNVBAMMEXd3dy5leGFtcGxlY2EuY29tMSIwIAYJKoZIhvcNAQkBFhNleGFt\ncGxlQGV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\nw2rK1J2NMtQj0KDug7g7HRKl5jbf0QMkMKyTU1fBtZ0cCzvsF4CqV11LK4BSVWaK\nrzkaXe99IVJnH8KdOlDl5Dh/+cJ3xdkClSyeUT4zgb6CCBqg78ePp+nN11JKuJlV\nIG1qdJpB1J5O/kCLsGcTf7RS74MtqMFo96446Zvt7YaBhWPz6gDaO/TUzfrNcGLA\nEfHVXkvVWqb3gqXUztZyVex/gtP9FXQ7gxTvJml7UkmT0VAFjtZnCqmFxpLZFZ15\n+qP9O7Q2MpsGUO/4vDAuYrKBeg1ZdPSi8gwqUP2qWsGd9MIWRv3thI2903BczDc7\nr8WaIbm37vYZAS9G56E4+wIDAQABo1AwTjAdBgNVHQ4EFgQUugLrSJshOBk5TSsU\nANs4+SmJUGwwHwYDVR0jBBgwFoAUugLrSJshOBk5TSsUANs4+SmJUGwwDAYDVR0T\nBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOCAQEAaMJ33zAMV4korHo5aPfayV3uHoYZ\n1ChzP3eSsF+FjoscpoNSKs91ZXZF6LquzoNezbfiihK4PYqgwVD2+O0/Ty7UjN4S\nqzFKVR4OS/6lCJ8YncxoFpTntbvjgojf1DEataKFUN196PAANc3yz8cWHF4uvjPv\nWkgFqbIjb+7D1YgglNyovXkRDlRZl0LD1OQ0ZWhd4Ge1qx8mmmanoBeYZ9+DgpFC\nj9tQAbS867yeOryNe7sEOIpXAAqK/DTu0hB6+ySsDfMo4piXCc2aA/eI2DCuw08e\nw17Dz9WnupZjVdwTKzDhFgJZMLDqn37HQnT6EemLFqbcR0VPEnfyhDtZIQ==\n-----END CERTIFICATE-----"
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "origin-ruby-sample",
+        "creationTimestamp": null
+      },
+      "spec": {},
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "ruby-22-centos7",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "dockerImageRepository": "centos/ruby-22-centos7"
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "kind": "BuildConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "ruby-sample-build",
+        "creationTimestamp": null,
+        "labels": {
+          "name": "ruby-sample-build"
+        }
+      },
+      "spec": {
+        "triggers": [
+          {
+            "type": "GitHub",
+            "github": {
+              "secret": "secret101"
+            }
+          },
+          {
+            "type": "Generic",
+            "generic": {
+              "secret": "secret101"
+            }
+          }
+        ],
+        "source": {
+          "type": "Git",
+          "git": {
+            "uri": "https://github.com/openshift/ruby-hello-world.git"
+          }
+        },
+        "strategy": {
+          "type": "Source",
+          "sourceStrategy": {
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "ruby-22-centos7:latest"
+            },
+            "env": [
+              {
+                "name": "EXAMPLE",
+                "value": "sample-app"
+              }
+            ]
+          }
+        },
+        "output": {
+          "to": {
+            "kind": "ImageStreamTag",
+            "name": "origin-ruby-sample:latest"
+          }
+        },
+        "postCommit": {
+          "args": ["bundle", "exec", "rake", "test"]
+        },
+        "resources": {}
+      },
+      "status": {
+        "lastVersion": 0
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "frontend",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "strategy": {
+          "type": "Rolling",
+          "rollingParams": {
+            "updatePeriodSeconds": 1,
+            "intervalSeconds": 1,
+            "timeoutSeconds": 120,
+            "pre": {
+              "failurePolicy": "Abort",
+              "execNewPod": {
+                "command": [
+                  "/bin/true"
+                ],
+                "env": [
+                  {
+                    "name": "CUSTOM_VAR1",
+                    "value": "custom_value1"
+                  }
+                ],
+                "containerName": "ruby-helloworld"
+              }
+            },
+            "post": {
+              "failurePolicy": "Ignore",
+              "execNewPod": {
+                "command": [
+                  "/bin/false"
+                ],
+                "env": [
+                  {
+                    "name": "CUSTOM_VAR2",
+                    "value": "custom_value2"
+                  }
+                ],
+                "containerName": "ruby-helloworld"
+              }
+            }
+          },
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "ruby-helloworld"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "origin-ruby-sample:latest"
+              }
+            }
+          }
+        ],
+        "replicas": 2,
+        "selector": {
+          "name": "frontend"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "name": "frontend"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "ruby-helloworld",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "ADMIN_USERNAME",
+                    "value": "${ADMIN_USERNAME}"
+                  },
+                  {
+                    "name": "ADMIN_PASSWORD",
+                    "value": "${ADMIN_PASSWORD}"
+                  },
+                  {
+                    "name": "MYSQL_USER",
+                    "value": "${MYSQL_USER}"
+                  },
+                  {
+                    "name": "MYSQL_PASSWORD",
+                    "value": "${MYSQL_PASSWORD}"
+                  },
+                  {
+                    "name": "MYSQL_DATABASE",
+                    "value": "${MYSQL_DATABASE}"
+                  }
+                ],
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "imagePullPolicy": "IfNotPresent",
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "dnsPolicy": "ClusterFirst"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "database",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "db",
+            "protocol": "TCP",
+            "port": 5434,
+            "targetPort": 3306,
+            "nodePort": 0
+          }
+        ],
+        "selector": {
+          "name": "database"
+        },
+        "portalIP": "",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "database",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "strategy": {
+          "type": "Recreate",
+          "recreateParams": {
+            "pre": {
+              "failurePolicy": "Abort",
+              "execNewPod": {
+                "command": [
+                  "/bin/true"
+                ],
+                "env": [
+                  {
+                    "name": "CUSTOM_VAR1",
+                    "value": "custom_value1"
+                  }
+                ],
+                "containerName": "ruby-helloworld-database",
+                "volumes": ["ruby-helloworld-data"]
+              }
+            },
+            "mid": {
+              "failurePolicy": "Abort",
+              "execNewPod": {
+                "command": [
+                  "/bin/true"
+                ],
+                "env": [
+                  {
+                    "name": "CUSTOM_VAR2",
+                    "value": "custom_value2"
+                  }
+                ],
+                "containerName": "ruby-helloworld-database",
+                "volumes": ["ruby-helloworld-data"]
+              }
+            },
+            "post": {
+              "failurePolicy": "Ignore",
+              "execNewPod": {
+                "command": [
+                  "/bin/false"
+                ],
+                "env": [
+                  {
+                    "name": "CUSTOM_VAR2",
+                    "value": "custom_value2"
+                  }
+                ],
+                "containerName": "ruby-helloworld-database",
+                "volumes": ["ruby-helloworld-data"]
+              }
+            }
+          },
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "replicas": 1,
+        "selector": {
+          "name": "database"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "name": "database"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "ruby-helloworld-database",
+                "image": "openshift/mysql-55-centos7:latest",
+                "ports": [
+                  {
+                    "containerPort": 3306,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "MYSQL_USER",
+                    "value": "${MYSQL_USER}"
+                  },
+                  {
+                    "name": "MYSQL_PASSWORD",
+                    "value": "${MYSQL_PASSWORD}"
+                  },
+                  {
+                    "name": "MYSQL_DATABASE",
+                    "value": "${MYSQL_DATABASE}"
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "ruby-helloworld-data",
+                    "mountPath": "/var/lib/mysql/data"
+                  }
+                ],
+                "terminationMessagePath": "/dev/termination-log",
+                "imagePullPolicy": "Always",
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+            "volumes": [
+              {
+                "name": "ruby-helloworld-data",
+                "emptyDir": {
+                  "medium": ""
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "dnsPolicy": "ClusterFirst"
+          }
+        }
+      },
+      "status": {}
+    }
+
+  ],
+  "parameters": [
+    {
+      "name": "ADMIN_USERNAME",
+      "description": "administrator username",
+      "generate": "expression",
+      "from": "admin[A-Z0-9]{3}"
+    },
+    {
+      "name": "ADMIN_PASSWORD",
+      "description": "administrator password",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{8}"
+    },
+    {
+      "name": "MYSQL_USER",
+      "description": "database username",
+      "generate": "expression",
+      "from": "user[A-Z0-9]{3}",
+      "required": true
+    },
+    {
+      "name": "MYSQL_PASSWORD",
+      "description": "database password",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{8}",
+      "required": true
+    },
+    {
+      "name": "MYSQL_DATABASE",
+      "description": "database name",
+      "value": "root",
+      "required": true
+    }
+  ],
+  "labels": {
+    "template": "application-template-stibuild"
+  }
+}

--- a/web/src/main/java/org/kontinuity/catapult/web/api/CatapultResource.java
+++ b/web/src/main/java/org/kontinuity/catapult/web/api/CatapultResource.java
@@ -41,6 +41,9 @@ public class CatapultResource {
     */
    private static final String QUERY_PARAM_SOURCE_REPO = "source_repo";
 
+   /** the name of the file containing the template to apply on the OpenShif project. */
+   private static final String OPENSHIFT_PROJECT_TEMPLATE = "openshift_template.json";
+   
    @Inject
    private Catapult catapult;
 
@@ -86,6 +89,7 @@ public class CatapultResource {
       final Projectile projectile = ProjectileBuilder.newInstance().
               sourceGitHubRepo(sourceGitHubRepo).
               gitHubAccessToken(gitHubAccessToken).
+              openshiftProjectTemplateFileName(OPENSHIFT_PROJECT_TEMPLATE).
               build();
 
       // Fling it

--- a/web/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/web/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
+    <deployment>
+        <exclusions>
+            <module name="org.jboss.resteasy.resteasy-jackson2-provider" />
+            <module name="com.fasterxml.jackson.core.jackson-annotations" />
+            <module name="com.fasterxml.jackson.core.jackson-core" />
+            <module name="com.fasterxml.jackson.core.jackson-databind" />
+            <module
+                name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" />
+        </exclusions>
+
+    </deployment>
+</jboss-deployment-structure>


### PR DESCRIPTION
Using the Kubernetes API:
- load the template from a file,
- process the template on the client side (would evaluate all parameters)
- apply the template on OpenShift in the namespace corresponding to the
  project that was created

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>