### PR TITLE
Fixes #156: Add Github templates for commit and PR messages

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,7 @@
+[apply]
+	whitespace = nowarn
+[branch]  
+ 	autosetuprebase = always
+[commit]
+	gpgsign = true
+	template = .github/gitcommit.txt

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,6 @@
+- [ ] Have you created an [issue](https://github.com/redhat-kontinuity/catapult/issues) and used it in the commit message?
+- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/redhat-kontinuity/catapult/pulls) for the same issue?
+- [ ] Have you built the project locally prior to submission with `mvn clean install`?
+
+-----
+

--- a/.github/gitcommit.txt
+++ b/.github/gitcommit.txt
@@ -1,0 +1,14 @@
+Fixes #XX: Subject of 50 chars or less followed by blank line.
+
+Motivation
+----------
+What is the purpose of this commit.
+
+Modifications
+-------------
+What code has changed, and in what way?
+
+Result
+------
+How does this commit affect the product in behavior or usage.
+

--- a/README.md
+++ b/README.md
@@ -158,3 +158,18 @@ Access to the CI environment has the following requirements:
  * The CI environment should now be available at [http://jenkins.master.distortion.example.com](http://jenkins.master.distortion.example.com)
 
  * Alternatively you can use http://jenkins.master.10.3.10.147.xip.io/ and you don't have to modify `hosts` file.
+
+
+Contributing
+------------
+
+* Clone the repository
+```
+	git clone https://github.com/redhat-kontinuity/catapult.git
+```
+
+* In the cloned repository, run the following commands to have your git configuration for this repository all set up: 
+```
+git config commit.template .github/gitcommit.txt --local
+git config commit.gpgsign true --local
+```


### PR DESCRIPTION
- [X] Have you created an [issue](https://github.com/redhat-kontinuity/catapult/issues) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/redhat-kontinuity/catapult/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
It would be nice to have a pattern for pull requests and commit messages

Modifications
-------------
Created .github directory and instructions in the README file

Result
------
Every new commit and PR in this repository will use the suggested template