### PR TITLE
Fix CI build script

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -22,11 +22,8 @@ ENV JAVA_HOME /usr/lib/jvm/java-openjdk
 
 RUN useradd --user-group --create-home --shell /bin/false ${USER_NAME}
 
-USER ${USER_NAME}
 WORKDIR ${HOME}
-
-RUN git clone https://github.com/redhat-kontinuity/catapult/ &&\
-    cd catapult &&\
-    mvn -B clean install
-
 COPY . ./
+RUN chown -R ${USER_NAME} ./
+
+USER ${USER_NAME}

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -41,7 +41,7 @@ mkdir ${TARGET_DIR}/
 docker run --detach=true --name ${BUILDER_CONT} -t -v $(pwd)/${TARGET_DIR}:/${TARGET_DIR}:Z ${BUILDER_IMAGE} /bin/tail -f /dev/null #FIXME
 
 docker exec ${BUILDER_CONT} mvn -B clean install
-docker exec -u root ${BUILDER_CONT} cp ${TARGET_DIR}/web/target/kontinuity-catapult.war /${TARGET_DIR}
+docker exec -u root ${BUILDER_CONT} cp web/target/kontinuity-catapult.war /${TARGET_DIR}
 
 #BUILD DEPLOY IMAGE
 docker build -t ${DEPLOY_IMAGE} -f Dockerfile.deploy .


### PR DESCRIPTION
The issue was that when you use `COPY` or `ADD` to get content to the image it keeps the ownership and permissions from the host, so everything copied in has been owned by `root`. That would be fine, but the repo contains `base` directory, which after cloning was owned by `root`, where `target` dir is created for output of  `mvn install`.

See https://github.com/docker/docker/issues/6119

I've reordered commands in Dockerfile and `chown`-ed the content of the repo.

This showed another issue with `cp` which tried to copy war from a wrong directory.