### PR TITLE
Introduced default value for EnvironmentSupport's getEnvVarOrSysProp

### DIFF
--- a/base/src/main/java/org/kontinuity/catapult/base/EnvironmentSupport.java
+++ b/base/src/main/java/org/kontinuity/catapult/base/EnvironmentSupport.java
@@ -11,8 +11,6 @@ public enum EnvironmentSupport {
 
    INSTANCE;
 
-   private final String MESSAGE_PATTERN = "Could not find required env var or sys prop {0}";
-
    /**
     * Obtains the environment variable or system property, with preference to the system
     * property in the case both are defined.  Returns null if not found.
@@ -39,6 +37,36 @@ public enum EnvironmentSupport {
    }
 
    /**
+    * Obtains the environment variable or system property, with preference to the system
+    * property in the case both are defined.  Returns null if not found.
+    *
+    * @param envVarOrSysProp the environment variable or system property name
+    * @param defaultValue    the default value to be returned if not available
+    * @return the environment variable or system property, with preference to the system
+    * property in the case both are defined; null if not found.
+    * @throws IllegalArgumentException If the env var or sysprop name is not specified
+    * @throws IllegalArgumentException If the defaultValue is not specified
+    */
+   public String getEnvVarOrSysProp(final String envVarOrSysProp, String defaultValue) throws IllegalArgumentException {
+      if (envVarOrSysProp == null || envVarOrSysProp.isEmpty()) {
+         throw new IllegalArgumentException("env var or sysprop name is required");
+      }
+      if (defaultValue == null || defaultValue.isEmpty()) {
+         throw new IllegalArgumentException("default value for " + envVarOrSysProp + " is required");
+      }
+      String value = System.getProperty(envVarOrSysProp);
+      if (value == null || value.isEmpty()) {
+         value = System.getenv(envVarOrSysProp);
+      }
+      // Set null or empty strings to default value
+      if (value == null || value.isEmpty()) {
+         value = defaultValue;
+      }
+
+      return value;
+   }
+
+   /**
     * Obtains the required environment variable or system property, with preference to the system
     * property in the case both are defined.
     *
@@ -51,7 +79,7 @@ public enum EnvironmentSupport {
            throws IllegalStateException, IllegalArgumentException {
       String value = getEnvVarOrSysProp(envVarOrSysProp);
       if (value == null || value.isEmpty()) {
-         final String errorMessage = MessageFormat.format(MESSAGE_PATTERN, envVarOrSysProp);
+         final String errorMessage = MessageFormat.format("Could not find required env var or sys prop {0}", envVarOrSysProp);
          throw new IllegalStateException(errorMessage);
       }
       return value;

--- a/base/src/test/java/org/kontinuity/catapult/base/EnvironmentSupportTest.java
+++ b/base/src/test/java/org/kontinuity/catapult/base/EnvironmentSupportTest.java
@@ -1,0 +1,29 @@
+package org.kontinuity.catapult.base;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+public class EnvironmentSupportTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetEnvVarOrSysPropDefaultShouldNotBeNull() {
+        EnvironmentSupport.INSTANCE.getEnvVarOrSysProp("foo",null);
+    }
+
+    @Test
+    public void testGetEnvVarOrSysProp() {
+        String pathSeparator = EnvironmentSupport.INSTANCE.getEnvVarOrSysProp("path.separator");
+        Assert.assertEquals(File.pathSeparator, pathSeparator);
+    }
+
+    @Test
+    public void testGetEnvVarOrSysPropDefault() {
+        String pathSeparator = EnvironmentSupport.INSTANCE.getEnvVarOrSysProp("path.separator.foo",File.pathSeparator);
+        Assert.assertEquals(File.pathSeparator, pathSeparator);
+    }
+}


### PR DESCRIPTION
- [x] Have you created an [issue](https://github.com/redhat-kontinuity/catapult/issues) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/redhat-kontinuity/catapult/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Some code check for the presence of getEnvVarOrSysProp and assume a different value otherwise.

Modifications
-------------
A new getEnvVarOrSysProp method with a signature accepting a default value is introduced

Result
------
Less lines of code for checking env vars or system property values