### PR TITLE
Core APIs should not have any implementation classes

### DIFF
--- a/core/core-api/src/main/java/org/kontinuity/catapult/core/api/Catapult.java
+++ b/core/core-api/src/main/java/org/kontinuity/catapult/core/api/Catapult.java
@@ -10,6 +10,12 @@ package org.kontinuity.catapult.core.api;
 public interface Catapult {
 
     /**
+     * Creates a {@link ProjectileBuilder} to be flinged in the {@link #fling(Projectile)} method
+     * @return A {@link ProjectileBuilder} instance
+     */
+    ProjectileBuilder newProjectileBuilder();
+
+    /**
      * The {@link Catapult}, as the name suggests, is a launcher.  Its responsibility
      * is to take the following inputs:
      * <ul>
@@ -42,6 +48,5 @@ public interface Catapult {
      * @return The result of the operation encapsulated in a {@link Boom}
      * @throws IllegalArgumentException If the {@link Projectile} is not specified
      */
-    public Boom fling(final Projectile projectile) throws IllegalArgumentException;
-
+    Boom fling(final Projectile projectile) throws IllegalArgumentException;
 }

--- a/core/core-api/src/main/java/org/kontinuity/catapult/core/api/Catapult.java
+++ b/core/core-api/src/main/java/org/kontinuity/catapult/core/api/Catapult.java
@@ -10,12 +10,6 @@ package org.kontinuity.catapult.core.api;
 public interface Catapult {
 
     /**
-     * Creates a {@link ProjectileBuilder} to be flinged in the {@link #fling(Projectile)} method
-     * @return A {@link ProjectileBuilder} instance
-     */
-    ProjectileBuilder newProjectileBuilder();
-
-    /**
      * The {@link Catapult}, as the name suggests, is a launcher.  Its responsibility
      * is to take the following inputs:
      * <ul>

--- a/core/core-api/src/main/java/org/kontinuity/catapult/core/api/Projectile.java
+++ b/core/core-api/src/main/java/org/kontinuity/catapult/core/api/Projectile.java
@@ -6,59 +6,31 @@ package org.kontinuity.catapult.core.api;
  *
  * @author <a href="mailto:alr@redhat.com">Andrew Lee Rubinger</a>
  */
-public class Projectile {
-
-    private final String sourceGitHubRepo;
-
-    private final String gitHubAccessToken;
-
-   /** the name of OpenShift project to create. */
-   private String openShiftProjectName;
-
-    /** the path to the file in the repo that contains the pipeline template. */
-    private String pipelineTemplatePath;
-
-   private final String gitRef;
-
-    /**
-     * Package-level access; to be invoked by {@link ProjectileBuilder}
-     * and all precondition checks are its responsibility
-     */
-    Projectile(final ProjectileBuilder builder){
-        this.sourceGitHubRepo = builder.getSourceGitHubRepo();
-        this.gitHubAccessToken = builder.getGitHubAccessToken();
-       this.openShiftProjectName = builder.getOpenShiftProjectName();
-        this.pipelineTemplatePath = builder.getPipelineTemplatePath();
-       this.gitRef = builder.getGitRef();
-    }
+public interface Projectile {
 
     /**
      * @return the GitHub access token we have obtained from the user as part of
      * the OAuth process
      */
-    public String getGitHubAccessToken() {
-        return this.gitHubAccessToken;
-    }
+    String getGitHubAccessToken();
 
     /**
      * @return source GitHub repository name in form "owner/repoName".
      */
-    public String getSourceGitHubRepo() {
-        return this.sourceGitHubRepo;
-    }
+    String getSourceGitHubRepo();
 
    /**
     * @return The name to use in creating the new OpenShift project
     */
-   public String getOpenShiftProjectName() { return openShiftProjectName;  }
+   String getOpenShiftProjectName();
 
    /**
     * @return The path to the pipeline template file in the repo
     */
-   public String getPipelineTemplatePath() { return pipelineTemplatePath; }
+   String getPipelineTemplatePath();
 
    /**
     * @return The Git reference to use
     */
-   public String getGitRef() { return gitRef; }
+   String getGitRef();
 }

--- a/core/core-api/src/main/java/org/kontinuity/catapult/core/api/ProjectileBuilder.java
+++ b/core/core-api/src/main/java/org/kontinuity/catapult/core/api/ProjectileBuilder.java
@@ -17,33 +17,7 @@ import java.util.regex.Pattern;
  *
  * @author <a href="mailto:alr@redhat.com">Andrew Lee Rubinger</a>
  */
-public class ProjectileBuilder {
-
-    private String sourceGitHubRepo;
-
-    private String gitHubAccessToken;
-
-   /** the name of OpenShift project to create. */
-   private String openShiftProjectName;
-
-   /** the path to the file in the repo that contains the pipeline template. */
-   private String pipelineTemplatePath;
-
-   private String gitRef;
-
-   private static final Pattern REPO_PATTERN = Pattern.compile("^[a-zA-Z_0-9\\-]+/[a-zA-Z_0-9\\-]+");
-
-    private ProjectileBuilder(){
-        // No external instances
-    }
-
-    /**
-     * Creates and returns a new instance with uninitialized values
-     * @return a new instance of the {@link ProjectileBuilder}
-     */
-    public static ProjectileBuilder newInstance(){
-        return new ProjectileBuilder();
-    }
+public interface ProjectileBuilder {
 
     /**
      * Creates and returns a new {@link Projectile} instance based on the
@@ -53,48 +27,7 @@ public class ProjectileBuilder {
      * @return the created {@link Projectile}
      * @throws IllegalStateException
      */
-    public Projectile build() throws IllegalStateException {
-       // Precondition checks
-       ProjectileBuilder.checkSpecified("sourceGitHubRepo", this.sourceGitHubRepo);
-       final Matcher matcher = REPO_PATTERN.matcher(sourceGitHubRepo);
-       if(!matcher.matches()) {
-          throw new IllegalStateException("source repo must be in form \"owner/repoName\"");
-       }
-       ProjectileBuilder.checkSpecified("gitHubAccessToken", this.gitHubAccessToken);
-       ProjectileBuilder.checkSpecified("pipelineTemplatePath", this.pipelineTemplatePath);
-       ProjectileBuilder.checkSpecified("girRef", this.gitRef);
-
-       // Default the openshiftProjectName if need be
-       try{
-          ProjectileBuilder.checkSpecified("openshiftProjectName", this.openShiftProjectName);
-       }
-       catch(final IllegalStateException ise){
-          final String  sourceGitHubRepo = this.getSourceGitHubRepo();
-          final String targetProjectName = this.getSourceGitHubRepo().substring(
-                  sourceGitHubRepo.lastIndexOf('/')+1);
-          this.openShiftProjectName(targetProjectName);
-       }
-
-        // All good, so make a new instance
-        final Projectile projectile = new Projectile(this);
-        return projectile;
-    }
-
-    /**
-     * Ensures the specified value is not null or empty, else throws
-     * an {@link IllegalArgumentException} citing the specified name
-     * (which is also required ;) )
-     *
-     * @param value
-     * @throws IllegalStateException
-     */
-    private static void checkSpecified(final String name,
-                                final String value) throws IllegalStateException {
-        assert name != null && !name.isEmpty() : "name is required";
-        if (value == null || value.isEmpty()) {
-            throw new IllegalStateException(name + " must be specified");
-        }
-    }
+    Projectile build() throws IllegalStateException;
 
     /**
      * Builder methods
@@ -106,10 +39,7 @@ public class ProjectileBuilder {
      * @param sourceGitHubRepo
      * @return This builder
      */
-    public ProjectileBuilder sourceGitHubRepo(final String sourceGitHubRepo){
-        this.sourceGitHubRepo = sourceGitHubRepo;
-        return this;
-    }
+    ProjectileBuilder sourceGitHubRepo(final String sourceGitHubRepo);
     
     /**
      * Sets the GitHub access token we have obtained from the user as part of
@@ -118,10 +48,7 @@ public class ProjectileBuilder {
      * @param gitHubAccessToken
      * @return This builder
      */
-    public ProjectileBuilder gitHubAccessToken(final String gitHubAccessToken) {
-        this.gitHubAccessToken = gitHubAccessToken;
-        return this;
-    }
+    ProjectileBuilder gitHubAccessToken(final String gitHubAccessToken);
 
    /**
     * Sets the path to file that contains the template to apply on the
@@ -130,10 +57,7 @@ public class ProjectileBuilder {
     * @param pipelineTemplatePath
     * @return This builder
     */
-   public ProjectileBuilder pipelineTemplatePath(final String pipelineTemplatePath) {
-      this.pipelineTemplatePath = pipelineTemplatePath;
-      return this;
-   }
+   ProjectileBuilder pipelineTemplatePath(final String pipelineTemplatePath);
 
    /**
     * Sets the name of the OpenShift project to create. By default, the name is derived from
@@ -141,10 +65,7 @@ public class ProjectileBuilder {
     * @param openShiftProjectName
     * @return This builder
     */
-   public ProjectileBuilder openShiftProjectName(final String openShiftProjectName) {
-      this.openShiftProjectName = openShiftProjectName;;
-      return this;
-   }
+   ProjectileBuilder openShiftProjectName(final String openShiftProjectName);
 
    /**
     * Sets Git ref to use. Required
@@ -152,38 +73,5 @@ public class ProjectileBuilder {
     * @param gitRef
     * @return This builder
     */
-   public ProjectileBuilder gitRef(final String gitRef) {
-      this.gitRef = gitRef;
-      return this;
-   }
-
-	/**
-     * @return source GitHub repository name in form "owner/repoName".
-     */
-    public String getSourceGitHubRepo() {
-        return this.sourceGitHubRepo;
-    }
-
-    /**
-     * @return the GitHub access token we have obtained from the user as part of
-     * the OAuth process
-     */
-    public String getGitHubAccessToken() {
-        return this.gitHubAccessToken;
-    }
-
-   /**
-    * @return The name to use in creating the new OpenShift project
-    */
-   public String getOpenShiftProjectName() { return openShiftProjectName;  }
-
-   /**
-    * @return the path to the file that contains the template to apply on the OpenShift project.
-    */
-   public String getPipelineTemplatePath() { return this.pipelineTemplatePath; }
-
-   /**
-    * @return The Git reference to use
-    */
-   public String getGitRef() { return gitRef; }
+   ProjectileBuilder gitRef(final String gitRef);
 }

--- a/core/core-impl/src/main/java/org/kontinuity/catapult/core/impl/CatapultImpl.java
+++ b/core/core-impl/src/main/java/org/kontinuity/catapult/core/impl/CatapultImpl.java
@@ -32,12 +32,6 @@ public class CatapultImpl implements Catapult {
 	@Inject
 	private GitHubServiceFactory gitHubServiceFactory;
 
-
-    @Override
-    public org.kontinuity.catapult.core.api.ProjectileBuilder newProjectileBuilder() {
-        return new ProjectileBuilderImpl();
-    }
-
     /**
      * {@inheritDoc}
      */

--- a/core/core-impl/src/main/java/org/kontinuity/catapult/core/impl/CatapultImpl.java
+++ b/core/core-impl/src/main/java/org/kontinuity/catapult/core/impl/CatapultImpl.java
@@ -12,7 +12,6 @@ import org.kontinuity.catapult.core.api.Boom;
 import org.kontinuity.catapult.core.api.Catapult;
 import org.kontinuity.catapult.core.api.Projectile;
 import org.kontinuity.catapult.service.github.api.*;
-import org.kontinuity.catapult.service.github.impl.kohsuke.KohsukeGitHubServiceImpl;
 import org.kontinuity.catapult.service.github.spi.GitHubServiceSpi;
 import org.kontinuity.catapult.service.openshift.api.DuplicateProjectException;
 import org.kontinuity.catapult.service.openshift.api.OpenShiftProject;
@@ -31,8 +30,14 @@ public class CatapultImpl implements Catapult {
 	private OpenShiftService openShiftService;
 
 	@Inject
-	private GitHubServiceFactory gitHubServiceFactory; 
-	
+	private GitHubServiceFactory gitHubServiceFactory;
+
+
+    @Override
+    public org.kontinuity.catapult.core.api.ProjectileBuilder newProjectileBuilder() {
+        return new ProjectileBuilderImpl();
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/core/core-impl/src/main/java/org/kontinuity/catapult/core/impl/ProjectileBuilderImpl.java
+++ b/core/core-impl/src/main/java/org/kontinuity/catapult/core/impl/ProjectileBuilderImpl.java
@@ -1,0 +1,197 @@
+package org.kontinuity.catapult.core.impl;
+
+import org.kontinuity.catapult.core.api.Projectile;
+import org.kontinuity.catapult.core.api.ProjectileBuilder;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * DSL builder for creating {@link Projectile} objects.  Responsible for
+ * validating state before calling upon the {@link ProjectileBuilderImpl#build()}
+ * operation.  The following properties are required:
+ * <p>
+ * <ul>
+ * <li>sourceGitHubRepo</li>
+ * <li>gitHubAccessToken</li>
+ * </ul>
+ * <p>
+ * Each property's valid value and purpose is documented in its setter method.
+ *
+ * @author <a href="mailto:alr@redhat.com">Andrew Lee Rubinger</a>
+ */
+public class ProjectileBuilderImpl implements Projectile, ProjectileBuilder {
+
+    private String sourceGitHubRepo;
+
+    private String gitHubAccessToken;
+
+    /**
+     * the name of OpenShift project to create.
+     */
+    private String openShiftProjectName;
+
+    /**
+     * the path to the file in the repo that contains the pipeline template.
+     */
+    private String pipelineTemplatePath;
+
+    private String gitRef;
+
+    private static final Pattern REPO_PATTERN = Pattern.compile("^[a-zA-Z_0-9\\-]+/[a-zA-Z_0-9\\-]+");
+
+
+    /**
+     * Creates and returns a new {@link Projectile} instance based on the
+     * state of this builder; if any preconditions like missing properties
+     * or improper values exist, an {@link IllegalStateException} will be thrown
+     *
+     * @return the created {@link Projectile}
+     * @throws IllegalStateException
+     */
+    @Override
+    public Projectile build() throws IllegalStateException {
+        // Precondition checks
+        ProjectileBuilderImpl.checkSpecified("sourceGitHubRepo", this.sourceGitHubRepo);
+        final Matcher matcher = REPO_PATTERN.matcher(sourceGitHubRepo);
+        if (!matcher.matches()) {
+            throw new IllegalStateException("source repo must be in form \"owner/repoName\"");
+        }
+        ProjectileBuilderImpl.checkSpecified("gitHubAccessToken", this.gitHubAccessToken);
+        ProjectileBuilderImpl.checkSpecified("pipelineTemplatePath", this.pipelineTemplatePath);
+        ProjectileBuilderImpl.checkSpecified("girRef", this.gitRef);
+
+        // Default the openshiftProjectName if need be
+        try {
+            ProjectileBuilderImpl.checkSpecified("openshiftProjectName", this.openShiftProjectName);
+        } catch (final IllegalStateException ise) {
+            final String sourceGitHubRepo = this.getSourceGitHubRepo();
+            final String targetProjectName = this.getSourceGitHubRepo().substring(
+                    sourceGitHubRepo.lastIndexOf('/') + 1);
+            this.openShiftProjectName(targetProjectName);
+        }
+
+        return this;
+    }
+
+    /**
+     * Ensures the specified value is not null or empty, else throws
+     * an {@link IllegalArgumentException} citing the specified name
+     * (which is also required ;) )
+     *
+     * @param value
+     * @throws IllegalStateException
+     */
+    private static void checkSpecified(final String name,
+                                       final String value) throws IllegalStateException {
+        assert name != null && !name.isEmpty() : "name is required";
+        if (value == null || value.isEmpty()) {
+            throw new IllegalStateException(name + " must be specified");
+        }
+    }
+
+    /**
+     * Builder methods
+     */
+
+    /**
+     * Sets the source GitHub repository name in form "owner/repoName"; this
+     * is what will be forked on behalf of the user.  Required.
+     *
+     * @param sourceGitHubRepo
+     * @return This builder
+     */
+    public ProjectileBuilderImpl sourceGitHubRepo(final String sourceGitHubRepo) {
+        this.sourceGitHubRepo = sourceGitHubRepo;
+        return this;
+    }
+
+    /**
+     * Sets the GitHub access token we have obtained from the user as part of
+     * the OAuth process. Required.
+     *
+     * @param gitHubAccessToken
+     * @return This builder
+     */
+    public ProjectileBuilderImpl gitHubAccessToken(final String gitHubAccessToken) {
+        this.gitHubAccessToken = gitHubAccessToken;
+        return this;
+    }
+
+    /**
+     * Sets the path to file that contains the template to apply on the
+     * OpenShift project. Required.
+     *
+     * @param pipelineTemplatePath
+     * @return This builder
+     */
+    public ProjectileBuilderImpl pipelineTemplatePath(final String pipelineTemplatePath) {
+        this.pipelineTemplatePath = pipelineTemplatePath;
+        return this;
+    }
+
+    /**
+     * Sets the name of the OpenShift project to create. By default, the name is derived from
+     * the GitHub repository to fork. Optional.
+     *
+     * @param openShiftProjectName
+     * @return This builder
+     */
+    public ProjectileBuilderImpl openShiftProjectName(final String openShiftProjectName) {
+        this.openShiftProjectName = openShiftProjectName;
+        return this;
+    }
+
+    /**
+     * Sets Git ref to use. Required
+     *
+     * @param gitRef
+     * @return This builder
+     */
+    @Override
+    public ProjectileBuilderImpl gitRef(final String gitRef) {
+        this.gitRef = gitRef;
+        return this;
+    }
+
+    /**
+     * @return source GitHub repository name in form "owner/repoName".
+     */
+    @Override
+    public String getSourceGitHubRepo() {
+        return this.sourceGitHubRepo;
+    }
+
+    /**
+     * @return the GitHub access token we have obtained from the user as part of
+     * the OAuth process
+     */
+    @Override
+    public String getGitHubAccessToken() {
+        return this.gitHubAccessToken;
+    }
+
+    /**
+     * @return The name to use in creating the new OpenShift project
+     */
+    @Override
+    public String getOpenShiftProjectName() {
+        return openShiftProjectName;
+    }
+
+    /**
+     * @return the path to the file that contains the template to apply on the OpenShift project.
+     */
+    @Override
+    public String getPipelineTemplatePath() {
+        return this.pipelineTemplatePath;
+    }
+
+    /**
+     * @return The Git reference to use
+     */
+    @Override
+    public String getGitRef() {
+        return gitRef;
+    }
+}

--- a/core/core-impl/src/test/java/org/kontinuity/catapult/core/impl/CatapultIT.java
+++ b/core/core-impl/src/test/java/org/kontinuity/catapult/core/impl/CatapultIT.java
@@ -118,7 +118,7 @@ public class CatapultIT {
     public void fling() {
         // Define the projectile with a custom, unique OpenShift project name.
     	final String expectedName = getUniqueProjectName();
-        final Projectile projectile = ProjectileBuilder.newInstance()
+        final Projectile projectile = new ProjectileBuilderImpl()
                 .gitHubAccessToken(GitHubTestCredentials.getToken())
                 .sourceGitHubRepo(GITHUB_SOURCE_REPO_FULLNAME)
                 .gitRef(GIT_REF)

--- a/core/core-impl/src/test/java/org/kontinuity/catapult/core/impl/ProjectileBuilderTest.java
+++ b/core/core-impl/src/test/java/org/kontinuity/catapult/core/impl/ProjectileBuilderTest.java
@@ -78,7 +78,7 @@ public class ProjectileBuilderTest {
 
 	@Test(expected = IllegalStateException.class)
 	public void sourceRepoMustBeInCorrectForm(){
-		ProjectileBuilder.newInstance().sourceGitHubRepo("doesntFollowForm").build();
+		new ProjectileBuilderImpl().sourceGitHubRepo("doesntFollowForm").build();
 	}
 
 	@Test
@@ -103,7 +103,7 @@ public class ProjectileBuilderTest {
 	 * set one property to empty and test {@link ProjectileBuilder#build()}
 	 */
 	private ProjectileBuilder getPopulatedBuilder(){
-		return ProjectileBuilder.newInstance()
+		return new ProjectileBuilderImpl()
 				.sourceGitHubRepo(REPO_VALUE)
 				.gitHubAccessToken(SOME_VALUE)
 				.openShiftProjectName(SOME_VALUE)

--- a/web/src/main/java/org/kontinuity/catapult/web/api/CatapultResource.java
+++ b/web/src/main/java/org/kontinuity/catapult/web/api/CatapultResource.java
@@ -50,6 +50,9 @@ public class CatapultResource {
    @Inject
    private Catapult catapult;
 
+   @Inject
+   private ProjectileBuilder projectileBuilder;
+
    @GET
    @Path(PATH_FLING)
    public Response fling(
@@ -100,7 +103,7 @@ public class CatapultResource {
          return Response.temporaryRedirect(gitHubOAuthUri).build();
       }
       // Construct the projectile based on input query param and the access token from the session
-      final Projectile projectile = catapult.newProjectileBuilder()
+      final Projectile projectile = projectileBuilder
               .sourceGitHubRepo(sourceGitHubRepo)
               .gitHubAccessToken(gitHubAccessToken)
               .gitRef(gitRef)

--- a/web/src/main/java/org/kontinuity/catapult/web/api/CatapultResource.java
+++ b/web/src/main/java/org/kontinuity/catapult/web/api/CatapultResource.java
@@ -100,7 +100,7 @@ public class CatapultResource {
          return Response.temporaryRedirect(gitHubOAuthUri).build();
       }
       // Construct the projectile based on input query param and the access token from the session
-      final Projectile projectile = ProjectileBuilder.newInstance()
+      final Projectile projectile = catapult.newProjectileBuilder()
               .sourceGitHubRepo(sourceGitHubRepo)
               .gitHubAccessToken(gitHubAccessToken)
               .gitRef(gitRef)


### PR DESCRIPTION
- [ ] Have you created an [issue](https://github.com/redhat-kontinuity/catapult/issues) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/redhat-kontinuity/catapult/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

This cleans up the catapult API to contain only interfaces and provide any implementation in core-impl.